### PR TITLE
Lays foundation for Science Lore section

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -2,15 +2,15 @@
 # Welcome  ![BS12](https://baystation12.net/forums/logo.png) 
 
 
-Welcome to the Lore Wiki for Baystation12. This is where you can find all the background, fluff, lore, and information for the universe of our server in an easy to read guides.
+Welcome to the Lore Wiki for Baystation12. This is where you can find all the background, fluff, lore, and information for the universe of our server in easy to read guides.
 
 ## Sections
 
 * [Welcome to the Milky Way, Circa 2560](https://baystation12.net/lore/Section-1)
-* [Humans, Aliens, and Monsters oh my!](https://baystation12.net/lore/Section-2)
+* [Humans, Aliens, and Monsters, Oh My!](https://baystation12.net/lore/Section-2)
 * [Colonies, From Mining Hubs to New New New York!](https://baystation12.net/lore/Section-4)
-* [Planets? Bluespace? SUPERMATTER? Welcome to Science](http://baystation12.net/lore/Section-7)
-* [So You Want to Go Corporate?](https://baystation12.net/lore/Section-3)
+* [Planets? Bluespace? Supermatter?! Welcome to SCIENCE!!!](http://baystation12.net/lore/Section-7)
+* [So You Want to Learn the Corporate Ways?](https://baystation12.net/lore/Section-3)
 * [Terrorism and You!](https://baystation12.net/lore/Section-5)
 * [What Else Do You Want to Know?](https://baystation12.net/lore/Section-6)
 * [Glossary of Terms](https://baystation12.net/lore/Glossary)

--- a/Section 7.md
+++ b/Section 7.md
@@ -1,0 +1,14 @@
+# Planets? Bluespace? Supermatter?! Welcome to SCIENCE!!!
+
+Since you will be working on NSS Exodus, which is a research station, you may want to learn some things that your character may be supposed to know in the game. Here is a quick summary to get you started, as well as more detailed articles if you are interested in SCIENCE!
+***
+
+- [**Bluespace**](https://baystation12.net/lore/Bluespace)
+
+	A parallel dimension to our own that consists entirely of Dark Matter, it is named according to the phenomenon seen by probes and passing shielded vessels. It has offered many breakthroughs in areas of communication, transportation, and more.
+    
+- [**Supermatter**](https://baystation12.net/lore/Supermatter)
+
+	A pristine crystalline structure made of solidified Phoron, it possesses unique and unrivaled energetic properties, but is kept together by a frail balance of two immense forces.
+    
+### More coming later!!!


### PR DESCRIPTION
Fixes a typo in Home page and makes the link title match with the Science section title.

Science section page added with a few things that could belong there as an example.
