### PR TITLE
Fixed typo

### DIFF
--- a/Section 4.md
+++ b/Section 4.md
@@ -49,7 +49,7 @@ These are colonies that exist in other systems besides Sol or Nyx
 
 ### Skrell 
 
-#### Harr'klem
+#### Harr'kelm
 
   * [Harr'qac](https://baystation12.net/lore/Planets-and-Systems/Harr'qac)
 


### PR DESCRIPTION
FIxed a typo
`Harr'klem` --> `Harr'kelm`
It should be Harr'kelm (refer to [Harr'qac page](https://github.com/Baystation12/Baystation12-Lore/blob/master/Planets%20and%20Systems/Harr'qac.md))